### PR TITLE
improve feature: make list item clickable in touch device

### DIFF
--- a/example/example-data.json
+++ b/example/example-data.json
@@ -1,0 +1,152 @@
+[
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  },
+  {
+    "name": {
+      "first":"zhihu",
+      "last": "kanshan"
+    }
+  }
+]

--- a/example/example.js
+++ b/example/example.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Hammer from 'hammerjs';
+import Tabular from '../src/index.jsx';
+
+class ExampleApp extends React.Component {
+  getDataSource() {
+    return require('json!./example-data.json');
+  }
+  render() {
+    return (
+      <Tabular getDataSource={this.getDataSource}
+        tableHeight={1000}
+        tableWidth={800}
+        columns={[
+          {
+            title: 'first name',
+            key: 'name.first',
+            onClick: function () {
+              alert('click');
+            },
+          },
+          {
+            title: 'last name',
+            key: 'name.last'
+          },
+          {
+            title: 'created',
+            key: 'created',
+            type: 'date'
+          }
+        ]}
+      />
+    );
+  }
+}
+
+ReactDOM.render(<ExampleApp />, document.getElementById('root-container'));

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Index</title>
+  </head>
+  <body>
+    <div id='root-container'>
+    </div>
+    <script src="/build.js"></script>
+  </body>
+</html>

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "example.js",
+  "scripts": {
+    "dev": "webpack-dev-server --hot --inline --devtool inline-source-map --progress --colors"
+  },
+  "dependencies": {
+    "react-hot-loader": "1.3.0",
+    "babel-polyfill": "6.3.14",
+    "webpack-dev-server": "1.14.0",
+    "json-loader": "0.5.4"
+  },
+  "author": "jkvim <jkvim@outlook.com> (http://jkvim.me)"
+}

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,0 +1,32 @@
+"use strict";
+module.exports = {
+  entry: ['babel-polyfill', 'webpack/hot/dev-server', './example.js'],
+  output: {
+    path: './',
+    filename: 'build.js'
+  },
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$'/,
+        loader: 'react-hot',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['react', 'es2015', 'stage-0']
+        }
+      },
+      {
+        test: /\.css$/,
+        loader: 'style-loader!css-loader'
+      }
+    ]
+  },
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/weflex/react-touchable-tabular#readme",
   "dependencies": {
     "fixed-data-table": "0.6.0",
-    "scroller": "0.0.3"
+    "hammerjs": "2.0.6"
   },
   "peerDependencies": {
     "react": "0.14.3",


### PR DESCRIPTION
### make the table clickable and add a example for dev test

issue: https://github.com/weflex/react-touchable-tabular/issues/1

refer to the implement in admin

run example:  run `npm install && npm run dev` inside `example`, open the link `http://localhost:8080` and you can test touch in chrome devtool Device Mode. i have add clickEventListener on row1, so you can click any cell in row1 and it will alert an messenger.

BTW, npm@3 had change the behavior of peerDependecies that [stop auto-installing peerDependencies](https://github.com/npm/npm/issues/6565) and if we want to run the example we have to install moment, react, and react-dom  manually, should i add these library to devDenpencies?

R=@yorkie
